### PR TITLE
Fixed an issue Query Advanced Build is compiling too frequently

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
         "title": "SQL: Query Advancer Build"
       },
       {
+        "command": "extension.runQueryBuild",
+        "title": "SQL: Run Query Advancer Build"
+      },
+      {
         "command": "extension.saveConfig",
         "title": "SQL: Save current server"
       }
@@ -58,6 +62,11 @@
       {
         "key": "Ctrl+Alt+q",
         "command": "extension.queryBuild"
+      },
+      {
+        "key": "Ctrl+enter",
+        "mac": "cmd+enter",
+        "command": "extension.runQueryBuild"
       }
     ],
     "snippets": [


### PR DESCRIPTION
Fixed #13 

- [x] Trigger Execute Query Advanced Build
    * "files.autoSave"
        * "off": `On File Save` or `ctrl+enter` (mac: `cmd+enter`)
        * else : `ctrl+enter` (mac: `cmd+enter`)
- [x] An error occurred when `.vscode` folder is not exists
- [x] Add multiple SQL statements

