### PR TITLE
Commands visibility restriction in command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,24 @@
 			}
 		],
 		"menus": {
+			"commandPalette": [
+				{
+					"command": "extension.queryFileSQL",
+					"when": "editorLangId == 'sql'"
+				},
+				{
+					"command": "extension.queryFileSQLToCSV",
+					"when": "editorLangId == 'sql'"
+				},
+				{
+					"command": "extension.querySelectedSQL",
+					"when": "editorHasSelection && editorLangId == 'sql'"
+				},
+				{
+					"command": "extension.querySelectedSQLToCSV",
+					"when": "editorHasSelection && editorLangId == 'sql'"
+				}
+			],
 			"editor/context": [
 				{
 					"command": "extension.querySelectedSQL",


### PR DESCRIPTION
Restricted the visibility of SQL files related commands:
1. **Run File as query** and **Run file as query with CSV result** will show up only when a SQL file is selected in the editor.
2. **Run selected text as SQL query** and **Run selected text as SQL query with CSV result** will show up only when a SQL file is selected in the editor and a portion of the text is selected.