### PR TITLE
activationEvents: lazy load extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,18 @@
 		"Other"
 	],
 	"activationEvents": [
-		"*"
+		"onLanguage:sql",
+		"onCommand:extension.connectToSQLServer",
+		"onCommand:extension.changeDB",
+		"onCommand:extension.changeServer",
+		"onCommand:extension.querySQL",
+		"onCommand:extension.queryFileSQL",
+		"onCommand:extension.queryFileSQLToCSV",
+		"onCommand:extension.querySelectedSQL",
+		"onCommand:extension.querySelectedSQLToCSV",
+		"onCommand:extension.queryBuild",
+		"onCommand:extension.runQueryBuild",
+		"onCommand:extension.saveConfig"
 	],
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
VSCode lazy loads extensions, listening on `activationEvents`
and evaluating JS + activate() when one of those events happens.
The idea is to prevent loading everything on startup.

Before, this extension would activate on VSCode startup always.

Now, it only activates:
- if you open a .sql file
- if you run any `SQL:` commands

Reproduction:
1. make an empty folder: `mkdir ~/example`
2. Run extension, open folder `~/example`
3. Run `Developer: Show Running Extensions`
Before: vscode-database should be loaded
After: vscode-daabase should not be loaded

PS: how do you normally test this package? Starting it with "Run Extension" causes all extensions to be disabled, even on master.